### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -13,7 +13,7 @@ class action_plugin_osm extends DokuWiki_Action_Plugin {
   /**
    * Register its handlers with the dokuwiki's event controller
    */
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE',  $this, '_hookjs');
   }
 

--- a/syntax.php
+++ b/syntax.php
@@ -53,7 +53,7 @@ class syntax_plugin_osm extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('<osm ?[^>\n]*>.*?</osm>', $mode, 'plugin_osm');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 
         // break matched cdata into its components
         list($str_params, $str_markers) = explode('>', substr($match, 4, -6), 2);
@@ -92,7 +92,7 @@ class syntax_plugin_osm extends DokuWiki_Syntax_Plugin {
         return array($opts, $markers);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
             list($options, $markers) = $data;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
